### PR TITLE
docs: update nextjs documentation

### DIFF
--- a/apps/docs/content/en/docs/04-community/02-rspack.mdx
+++ b/apps/docs/content/en/docs/04-community/02-rspack.mdx
@@ -1,0 +1,12 @@
+---
+title: Rspack Integration
+nav_title: Rspack
+description: Use the `next-rspack` plugin to bundle your Next.js with Rspack.
+version: experimental
+---
+
+The Rspack team has created a community plugin for Next.js, which is part of a [partnering effort](https://rspack.rs/blog/rspack-next-partner) with the Rspack team.
+
+This plugin is currently experimental. Please use this [discussion thread](https://github.com/vercel/next.js/discussions/77800) to give feedback on any issues you encounter.
+
+Learn more on the [Rspack docs](https://rspack.rs/guide/tech/next) and try out [this example](https://github.com/vercel/next.js/tree/canary/examples/with-rspack).


### PR DESCRIPTION
This PR updates the Next.js English documentation from the official Next.js repository.
- Updates from `canary` branch to `apps/docs/content/en/docs`
- Updates from `v14.2.28` branch to `apps/docs/content/en/docs/14`
- Updates from `v13.5.11` branch to `apps/docs/content/en/docs/13`
- Updates from blog to `apps/docs/content/en/blog`
- Updates from learn to `apps/docs/content/en/learn`